### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.7
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v4.2.2
       with:
         distribution: 'temurin'
         java-version: 21

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,9 +13,9 @@ jobs:
         echo Version: $VERSION
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.7
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v4.2.2
       with:
         distribution: 'temurin'
         java-version: 22

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,15 +55,15 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.7
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v4.2.2
       with:
         distribution: 'temurin'
         java-version: 22
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@codeql-bundle-20230524
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -85,6 +85,6 @@ jobs:
       run: ./gradlew build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@codeql-bundle-20230524
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230524](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230524)** on 2023-05-24T16:01:13Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.2.2](https://github.com/actions/setup-java/releases/tag/v4.2.2)** on 2024-08-05T14:04:36Z
