### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.1
 
     - name: Setup Java
-      uses: actions/setup-java@v4.2.2
+      uses: actions/setup-java@v4.4.0
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v4.1.0
 
     - name: Build
       run: ./gradlew build

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.1
 
     - name: Setup Java
-      uses: actions/setup-java@v4.2.2
+      uses: actions/setup-java@v4.4.0
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v4.1.0
 
     - name: Build
       run: ./gradlew build sourcesJar javadocJar publish

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,18 +17,18 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Checkout sources
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: 0
 
     - name: Setup Java
-      uses: actions/setup-java@v4.2.2
+      uses: actions/setup-java@v4.4.0
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v4.1.0
 
     - name: Build
       env:
@@ -60,7 +60,7 @@ jobs:
       run: sed -i "s/com\.xemantic\.kotlin:xemantic-kotlin-swing-dsl-\(core\|test\):[0-9]\+\(\.[0-9]\+\)*\>/com.xemantic.kotlin:xemantic-kotlin-swing-dsl-\1:$VERSION/g" README.md
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v7.0.5
       with:
         token: ${{ secrets.WORKFLOW_SECRET }}
         commit-message: README.md gradle dependencies update to ${{ env.VERSION }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.4.0](https://github.com/actions/setup-java/releases/tag/v4.4.0)** on 2024-09-24T14:04:01Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.5](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.5)** on 2024-09-18T17:41:45Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v4.1.0](https://github.com/gradle/actions/releases/tag/v4.1.0)** on 2024-09-13T03:03:25Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.1](https://github.com/actions/checkout/releases/tag/v4.2.1)** on 2024-10-07T16:44:53Z
