### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -15,13 +15,13 @@ jobs:
       uses: actions/checkout@v4.2.2
 
     - name: Setup Java
-      uses: actions/setup-java@v4.6.0
+      uses: actions/setup-java@v4.7.1
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.2.2
+      uses: gradle/actions/setup-gradle@v4.4.1
 
     - name: Build
       run: ./gradlew build

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -11,13 +11,13 @@ jobs:
       uses: actions/checkout@v4.2.2
 
     - name: Setup Java
-      uses: actions/setup-java@v4.6.0
+      uses: actions/setup-java@v4.7.1
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.2.2
+      uses: gradle/actions/setup-gradle@v4.4.1
 
     - name: Build
       run: ./gradlew build sourcesJar javadocJar publish

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,13 +22,13 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Java
-      uses: actions/setup-java@v4.6.0
+      uses: actions/setup-java@v4.7.1
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.2.2
+      uses: gradle/actions/setup-gradle@v4.4.1
 
     - name: Build
       env:
@@ -60,7 +60,7 @@ jobs:
       run: sed -i "s/com\.xemantic\.kotlin:xemantic-kotlin-swing-dsl-\(core\|test\):[0-9]\+\(\.[0-9]\+\)*\>/com.xemantic.kotlin:xemantic-kotlin-swing-dsl-\1:$VERSION/g" README.md
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7.0.6
+      uses: peter-evans/create-pull-request@v7.0.8
       with:
         token: ${{ secrets.WORKFLOW_SECRET }}
         commit-message: README.md gradle dependencies update to ${{ env.VERSION }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.8](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.8)** on 2025-03-04T10:35:28Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.7.1](https://github.com/actions/setup-java/releases/tag/v4.7.1)** on 2025-04-09T02:58:20Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v4.4.1](https://github.com/gradle/actions/releases/tag/v4.4.1)** on 2025-06-11T21:38:16Z
