### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.4.1
+      uses: gradle/actions/setup-gradle@v4.4.2
 
     - name: Build
       run: ./gradlew build

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -17,7 +17,7 @@ jobs:
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.4.1
+      uses: gradle/actions/setup-gradle@v4.4.2
 
     - name: Build
       run: ./gradlew build sourcesJar javadocJar publish

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,7 +28,7 @@ jobs:
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.4.1
+      uses: gradle/actions/setup-gradle@v4.4.2
 
     - name: Build
       env:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v4.4.2](https://github.com/gradle/actions/releases/tag/v4.4.2)** on 2025-08-05T10:36:14Z
