### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v6.0.1
 
     - name: Setup Java
-      uses: actions/setup-java@v5.0.0
+      uses: actions/setup-java@v5.1.0
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.4.3
+      uses: gradle/actions/setup-gradle@v5.0.0
 
     - name: Build
       run: ./gradlew build

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v6.0.1
 
     - name: Setup Java
-      uses: actions/setup-java@v5.0.0
+      uses: actions/setup-java@v5.1.0
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.4.3
+      uses: gradle/actions/setup-gradle@v5.0.0
 
     - name: Build
       run: ./gradlew build sourcesJar javadocJar publish

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,18 +17,18 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Checkout sources
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v6.0.1
       with:
         fetch-depth: 0
 
     - name: Setup Java
-      uses: actions/setup-java@v5.0.0
+      uses: actions/setup-java@v5.1.0
       with:
         distribution: 'temurin'
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.4.3
+      uses: gradle/actions/setup-gradle@v5.0.0
 
     - name: Build
       env:
@@ -60,7 +60,7 @@ jobs:
       run: sed -i "s/com\.xemantic\.kotlin:xemantic-kotlin-swing-dsl-\(core\|test\):[0-9]\+\(\.[0-9]\+\)*\>/com.xemantic.kotlin:xemantic-kotlin-swing-dsl-\1:$VERSION/g" README.md
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7.0.8
+      uses: peter-evans/create-pull-request@v8.0.0
       with:
         token: ${{ secrets.WORKFLOW_SECRET }}
         commit-message: README.md gradle dependencies update to ${{ env.VERSION }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v8.0.0](https://github.com/peter-evans/create-pull-request/releases/tag/v8.0.0)** on 2025-12-09T20:24:51Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v5.0.0](https://github.com/gradle/actions/releases/tag/v5.0.0)** on 2025-10-01T10:09:40Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.1.0](https://github.com/actions/setup-java/releases/tag/v5.1.0)** on 2025-12-04T02:55:06Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)** on 2025-12-02T16:38:59Z
